### PR TITLE
fix deprecations and other updates

### DIFF
--- a/pytest_tags/pytest_tags.py
+++ b/pytest_tags/pytest_tags.py
@@ -15,7 +15,7 @@ import pytest
 
 @pytest.fixture(scope='session')
 def tags(request):
-    """Return a base URL"""
+    """Return commandline tags"""
     config = request.config
     tags = config.getoption('tags')
     if tags is not None:

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ from setuptools import setup
 
 setup(name='pytest-tags',
       use_scm_version=True,
-      description='pytest plugin for taggging tests',
+      description='pytest plugin for tagging tests',
       long_description=open('README.rst').read(),
-      author='Jim Brannlund',
-      author_email='jbrannlund@planview.com',
+      author='Planview',
+      author_email='baziz@planview.com',
       url='https://github.com/Projectplace/pytest-tags',
       packages=['pytest_tags'],
       entry_points={'pytest11': ['tags = pytest_tags.pytest_tags']},

--- a/testing/test_pytest_tags.py
+++ b/testing/test_pytest_tags.py
@@ -186,9 +186,9 @@ def test_header_selected_deselected(test_file):
 
 def test_header_output_no_tags(test_file):
     result = test_file.runpytest()
-    result.stdout.fnmatch_lines(["tags: ['all']"])
+    result.stdout.fnmatch_lines(["tags: all"])
 
 
 def test_header_output(test_file):
     result = test_file.runpytest('--tags', 'seven', 'two+three')
-    result.stdout.fnmatch_lines(["tags: ['seven', 'two+three']"])
+    result.stdout.fnmatch_lines(["tags: seven, two+three"])

--- a/tox.ini
+++ b/tox.ini
@@ -5,16 +5,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,36}-pytest{29,30,31,32,33}, flake8
+envlist = py{27,36}-pytest{29,37}, flake8
 
 [testenv]
 commands = py.test -v -r a {posargs}
 deps =
     pytest29: pytest==2.9.2
-    pytest30: pytest==3.0.7
-    pytest31: pytest==3.1.3
-    pytest32: pytest==3.2.5
-    pytest33: pytest==3.3.0
+    pytest37: pytest==3.7.2
 
 [testenv:flake8]
 skip_install = true
@@ -23,4 +20,4 @@ deps = flake8
 commands = flake8 {posargs:.}
 
 [flake8]
-exclude = .tox,build
+exclude = .eggs,.tox


### PR DESCRIPTION
`get_marker` is deprecated as of 3.6

https://docs.pytest.org/en/latest/mark.html#marker-revamp-and-iteration

I kept the code backwards compatible.

Other changes are mostly styling and polishing.